### PR TITLE
Fix header guard.

### DIFF
--- a/src/lineloop.h
+++ b/src/lineloop.h
@@ -17,7 +17,7 @@
  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#ifndef __LINeLoop_H__
+#ifndef __LINELOOP_H
 #define __LINELOOP_H
 
 typedef int (*lineprocessor_t)(char *line, void *data);


### PR DESCRIPTION
Fixes a compilation problem with clang 7 on macos 10.14.